### PR TITLE
rails 4.1.2, ruby 2.1.2, delete match routes and simple_captcha2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,11 @@
 source 'https://rubygems.org'
 
-ruby '1.9.3'
-gem 'rails', '3.2.2'
+#ruby '1.9.3'
+#gem 'rails', '3.2.2'
+ruby '2.1.2'
+# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
+gem 'rails', '4.1.2'
+gem 'rake', '10.3.2'
 
 # Bundle edge Rails instead:
 # gem 'rails', :git => 'git://github.com/rails/rails.git'
@@ -9,20 +13,32 @@ gem 'rails', '3.2.2'
 #gem 'sqlite3'
 
 #gema para conexion a mongodb
-gem 'mongoid', '~> 3.0.0'
-gem 'wolcanus-simple_captcha', :require => 'simple_captcha', :git => 'git://github.com/v1rtual/simple-captcha.git'
+#gem 'mongoid', '~> 3.0.0'
+gem 'mongoid', git: 'https://github.com/mongoid/mongoid.git'
+
+#gem 'wolcanus-simple_captcha', '~> 0.1.6' #:require => 'simple_captcha', :git => 'git://github.com/v1rtual/simple-captcha.git'
+gem 'simple_captcha2', require: 'simple_captcha'
+
+gem 'actionpack-page_caching'
+gem 'actionpack-action_caching'
+
 #gem "rserve-simpler", "~> 0.0.6"
 
 # Gems used only for assets and not required
 # in production environments by default.
 group :assets do
-  gem 'sass-rails',   '~> 3.2.3'
-  gem 'coffee-rails', '~> 3.2.1'
+  #gem 'sass-rails',   '~> 3.2.3'
+  gem 'sass-rails', '~> 4.0.0'
+
+  #gem 'coffee-rails', '~> 3.2.1'
+  gem 'coffee-rails', '~> 4.0.0'
 
   # See https://github.com/sstephenson/execjs#readme for more supported runtimes
   # gem 'therubyracer'
 
-  gem 'uglifier', '>= 1.0.3'
+  #gem 'uglifier', '>= 1.0.3'
+  gem 'uglifier', '>= 1.3.0'
+
   gem 'less-rails'
   gem 'twitter-bootstrap-rails'
 end
@@ -33,7 +49,8 @@ gem 'jquery-rails'
 gem 'blueimp-gallery', '~> 2.11.0.1'
 
 # To use ActiveModel has_secure_password
-gem 'bcrypt-ruby', '~> 3.0.0'
+# gem 'bcrypt-ruby', '~> 3.1.5'
+gem 'bcrypt'
 
 # To use Jbuilder templates for JSON
 # gem 'jbuilder'

--- a/config/application.rb
+++ b/config/application.rb
@@ -3,9 +3,8 @@ require File.expand_path('../boot', __FILE__)
 #require 'rails/all'
 require "action_controller/railtie"
 require "action_mailer/railtie"
-require "active_resource/railtie"
+#require "active_resource/railtie"
 require "rails/test_unit/railtie"
-require 'sprockets/railtie'
 
 if defined?(Bundler)
   # If you precompile assets before deploying to production, use this line

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,12 +6,12 @@ Ufo::Application.routes.draw do
 
   resources :sessions
 
-  match 'articles/myspace' => 'articles#myspace'
-  match 'articles/uforesearchteam' => 'articles#uforesearchteam'
+  get 'articles/myspace' => 'articles#myspace'
+  get 'articles/uforesearchteam' => 'articles#uforesearchteam'
 
   resources :articles
-  match 'articles/:id(/:title)' => 'articles#show'
-  match 'articles/:id' => 'articles#show'
+  get 'articles/:id(/:title)' => 'articles#show'
+  get 'articles/:id' => 'articles#show'
 
   get "sightings/index"
   # The priority is based upon order of creation:
@@ -65,20 +65,20 @@ Ufo::Application.routes.draw do
   # just remember to delete public/index.html.
   root :to => 'sightings#index'
   get 'reports/sightings', :to  => 'reports#sightings'
-  match 'reports/:id/country(.:format)' => 'reports#country'
-  match 'reports/nearof/:longitud/:latitud/nearest(.:format)' => 'reports#nearof', :constraints => { :longitud => /[^\/]+/, :latitud => /[^\/]+/}
+  get 'reports/:id/country(.:format)' => 'reports#country'
+  get 'reports/nearof/:longitud/:latitud/nearest(.:format)' => 'reports#nearof', :constraints => { :longitud => /[^\/]+/, :latitud => /[^\/]+/}
   resources :reports
 
   # root search and spain, same controller
   get 'sitemap', :to => 'sightings#sitemap'
-  match 'sightings/country/:id(/:title)' => 'sightings#country'
-  match 'sightings/search/:id(/:title)' => 'sightings#search'
-  match 'sightings/search/:id' => 'sightings#search'
-  match 'sightings/spain' => 'sightings#spain'
-  match 'stats' => 'stats#index'
+  get 'sightings/country/:id(/:title)' => 'sightings#country'
+  get 'sightings/search/:id(/:title)' => 'sightings#search'
+  get 'sightings/search/:id' => 'sightings#search'
+  get 'sightings/spain' => 'sightings#spain'
+  get 'stats' => 'stats#index'
   # See how all your routes lay out with "rake routes"
   # This is a legacy wild controller route that's not recommended for RESTful applications.
   # Note: This route will make all actions in every controller accessible via GET requests.
-  match ':controller(/:action(/:id))(.:format)'
+  get ':controller(/:action(/:id))(.:format)'
 
 end


### PR DESCRIPTION
- Update 

to rails 4.1.2
to ruby 2.1.2
- News gems in Gemfile - > 

Static page caching for Action Pack (removed from core in Rails 4.0):
gem 'actionpack-page_caching'
gem 'actionpack-action_caching'

SimpleCaptcha2 (https://github.com/pludoni/simple-captcha) with Rails 3 + 4:
gem 'simple_captcha2', require: 'simple_captcha'
- On routes, the match method will no longer act as a catch-all option. You should now specify which HTTP verb to respond to with the option :via

"get" instead of "match" ->

eje:
Rails 3.2
match "/users/:id" => "users#show"

Rails 4.0
match "/users/:id" => "users#show", via: :get

Rails 3.2 and 4.0 compatible
get "/users/:id" => "users#show"
