### PR TITLE
chore(puma): silence single-worker warning in production

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -12,8 +12,11 @@ environment ENV.fetch('RAILS_ENV', 'development')
 
 pidfile ENV.fetch('PIDFILE', 'tmp/pids/server.pid')
 
-workers ENV.fetch('WEB_CONCURRENCY', 1) if ENV.fetch('RAILS_ENV', 'development') == 'production'
-
-preload_app! if ENV.fetch('RAILS_ENV', 'development') == 'production'
+if ENV.fetch('RAILS_ENV', 'development') == 'production'
+  workers ENV.fetch('WEB_CONCURRENCY', 1)
+  # Single worker is intentional on this 984MB box; suppress Puma's nag.
+  silence_single_worker_warning
+  preload_app!
+end
 
 plugin :tmp_restart


### PR DESCRIPTION
## Summary

Production (984MB box) intentionally runs Puma in cluster mode with a single worker (`WEB_CONCURRENCY` defaults to 1). Puma logs a `Detected running cluster mode with 1 worker` warning on every boot — pure noise. Add `silence_single_worker_warning` to the production block.

## Test plan

- [x] `ruby -c config/puma.rb` — syntax OK
- [x] `silence_single_worker_warning` confirmed present in `Puma::DSL` (puma ~> 6.0)
- [x] `bundle exec rubocop config/puma.rb` — 0 offenses
- [ ] After deploy: confirm the warning no longer appears in `journalctl -u ufohunters` on boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)